### PR TITLE
Move application logic to library crate

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -47,9 +47,9 @@ fn categorize_arg_tokens(mut args: Args) -> Vec<Option> {
     args.next();
     while let option::Option::Some(arg_token) = args.next() {
         if arg_token == "-v" || arg_token == "--version" {
-            options.push(Option::Help);
-        } else if arg_token == "-h" || arg_token == "--help" {
             options.push(Option::Version);
+        } else if arg_token == "-h" || arg_token == "--help" {
+            options.push(Option::Help);
         } else if arg_token == "-c" || arg_token == "--config" {
             if let Some(file_config) = args.next() {
                 options = parse_config(&file_config);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,2 @@
+mod html_page;
+pub mod static_site;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 mod command;
-mod html_page;
-mod static_site;
+
 use command::Command;
-use static_site::StaticSite;
 use std::env;
 use std::path;
+use yassgy::static_site::StaticSite;
 
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");


### PR DESCRIPTION
Addresses issue #17.

To give the `tests` crate access, we would need to move the application logic into a library crate, by moving most of the declarations into `lib.rs`, and we will have a binary crate that includes the parsing command logic.